### PR TITLE
Cleaning up "TODO" section

### DIFF
--- a/notebooks/06.05-HBNet-Before-Design.ipynb
+++ b/notebooks/06.05-HBNet-Before-Design.ipynb
@@ -549,11 +549,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Programming Exercises\n",
-    "\n",
-    "- TODO\n",
-    "\n",
-    "\n",
     "## Thought Question\n",
     "\n",
     "The energy of HBNet+Design is often less favorable that the energy after an equivalent design run without HBNet. Why do people still use HBNet?\n",


### PR DESCRIPTION
I left the "Programming Exercises" section of the HBNet page blank with a giant "TODO". The chapter itself is one big exercise so I had a hard time thinking of small ones. This PR just removes that section altogether.