### PR TITLE
Update 06.04-Protein-Design-2.ipynb

### DIFF
--- a/notebooks/06.04-Protein-Design-2.ipynb
+++ b/notebooks/06.04-Protein-Design-2.ipynb
@@ -522,7 +522,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    " This time we will also setup a different `relaxscript` that optimizes the `ramp_repack_min` weights to prevent too many alanines from being designed (demonstrated at Pre-RosettaCON 2018 by Jack Maguire): "
+    " This time we will also setup a different `relaxscript` that optimizes the `ramp_repack_min` weights to prevent too many alanines from being designed (demonstrated at RosettaCON 2018 by Jack Maguire {note that this relaxscript is now default as of August 2019, so this option is only require for older versions of Rosetta} ): "
    ]
   },
   {
@@ -546,8 +546,8 @@
       "INFO:rosetta:\u001b[0mprotocols.relax.RelaxScriptManager: \u001b[0mtalaris2014 : 4.28436\n",
       "INFO:rosetta:\u001b[0mprotocols.relax.RelaxScriptManager: \u001b[0mref2015 : 1.8125\n",
       "INFO:rosetta:\u001b[0mprotocols.relax.RelaxScriptManager: \u001b[0mbeta_nov16 : 9.87535\n",
-      "INFO:rosetta:\u001b[0mprotocols.relax.RelaxScriptManager: \u001b[0mLooking for KillA2019.ref2015.txt\n",
-      "INFO:rosetta:\u001b[0mprotocols.relax.RelaxScriptManager: \u001b[0m================== Reading script file: /Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pyrosetta-2019.33+release.1e60c63beb5-py3.6-macosx-10.6-intel.egg/pyrosetta/database/sampling/relax_scripts/KillA2019.ref2015.txt ==================\n",
+      "INFO:rosetta:\u001b[0mprotocols.relax.RelaxScriptManager: \u001b[0mLooking for MonomerDesign2019.ref2015.txt\n",
+      "INFO:rosetta:\u001b[0mprotocols.relax.RelaxScriptManager: \u001b[0m================== Reading script file: /Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pyrosetta-2019.33+release.1e60c63beb5-py3.6-macosx-10.6-intel.egg/pyrosetta/database/sampling/relax_scripts/MonomerDesign2019.ref2015.txt ==================\n",
       "INFO:rosetta:\u001b[0mprotocols.relax.RelaxScriptManager: \u001b[0mrepeat %%nrepeats%%\n",
       "INFO:rosetta:\u001b[0mprotocols.relax.RelaxScriptManager: \u001b[0mreference -0.511909 2.0282 -3.29233 -3.74112 2.5917 -1.12843 -1.33724 3.25715 -1.56117 2.65488 2.88076 -2.80685 -1.5498 -2.69754 -1.62133 -1.86628 -0.0648395 2.6561 4.7344 1.37564\n",
       "INFO:rosetta:\u001b[0mprotocols.relax.RelaxScriptManager: \u001b[0mcoord_cst_weight 1.0\n",
@@ -578,7 +578,7 @@
     }
    ],
    "source": [
-    "rel_design = pyrosetta.rosetta.protocols.relax.FastRelax(scorefxn_in=scorefxn, standard_repeats=1, script_file=\"KillA2019\")\n",
+    "rel_design = pyrosetta.rosetta.protocols.relax.FastRelax(scorefxn_in=scorefxn, standard_repeats=1, script_file=\"MonomerDesign2019\")\n",
     "rel_design.cartesian(True)\n",
     "rel_design.set_task_factory(tf)\n",
     "rel_design.set_movemap(mm)\n",


### PR DESCRIPTION
This replaces KillA2019 (which has since been renamed to PolarDesign2019, though the KillA2019 name will still work) with MonomerDesign2019. We are still testing experimentally if KillA2019 is worthwhile but Hugh Haddox has experimental data that MonomerDesign2019 is superior.

This isn't a required change - nothing was false - but I think it would be good to advertise the best method.