### PR TITLE
Remove Second Declaration of FastRelax

### DIFF
--- a/notebooks/06.08-Point-Mutation-Scan.ipynb
+++ b/notebooks/06.08-Point-Mutation-Scan.ipynb
@@ -289,7 +289,6 @@
     "relax = FastRelax()\n",
     "scorefxn = get_fa_scorefxn()\n",
     "relax.set_scorefxn(scorefxn)\n",
-    "relax = rosetta.protocols.relax.FastRelax()\n",
     "relax.constrain_relax_to_start_coords(True)\n",
     "print(relax)\n",
     "#relax.apply(testPose)\n",


### PR DESCRIPTION
Creating the second fast relax object without setting its scorefunction and attempting to apply it will create a segmentation fault. Also the import for fast relax is above in the same cell so there is no need to use the whole rosetta.protocols.relax.FastRelax() syntax to create a new fast relax object.