### PR TITLE
Carbohydrates: Repairing broken test after function-name change

### DIFF
--- a/notebooks/13.01-Glycan-Trees-Selectors-and-Movers.ipynb
+++ b/notebooks/13.01-Glycan-Trees-Selectors-and-Movers.ipynb
@@ -664,7 +664,7 @@
     }
    ],
    "source": [
-    "info390.has_exocyclic_linkage_to_child_mainchain()"
+    "info390.has_mainchain_exocyclic_linkage_to_child()"
    ]
   },
   {


### PR DESCRIPTION
This merge will repair a test broken by RosettaCommons/main#5421.