### PR TITLE
Update 02.01-Pose-Basics.ipynb

### DIFF
--- a/student-notebooks/02.01-Pose-Basics.ipynb
+++ b/student-notebooks/02.01-Pose-Basics.ipynb
@@ -104,7 +104,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`cd google_drive/My\\ Drive/student-notebooks/`\n",
+    "`%cd google_drive/My\\ Drive/student-notebooks/`\n",
     "\n",
     "\n",
     "`pose = pose_from_pdb(\"5tj3.pdb\")`\n",


### PR DESCRIPTION
Since !cd creates a new shell which might be missed in next scripts, it's better to use %cd for correctly changing the directories. many students during BootCamp had problem with this, so I think it's good to add %cd notation to all notebooks.