### PR TITLE
Fix ImportError on newer IPython: import display/HTML from IPython.display

### DIFF
--- a/notebooks/06.03-Design-with-a-resfile-and-relax.ipynb
+++ b/notebooks/06.03-Design-with-a-resfile-and-relax.ipynb
@@ -92,7 +92,7 @@
     "import pyrosetta\n",
     "import pyrosetta.toolbox\n",
     "\n",
-    "from IPython.core.display import display, HTML\n",
+    "from IPython.display import display, HTML\n",
     "display(HTML(\"<style>.container { width:100% !important; }</style>\"))"
    ]
   },

--- a/notebooks/06.04-Protein-Design-2.ipynb
+++ b/notebooks/06.04-Protein-Design-2.ipynb
@@ -83,7 +83,7 @@
     "import pyrosetta.toolbox\n",
     "import site\n",
     "\n",
-    "from IPython.core.display import display, HTML\n",
+    "from IPython.display import display, HTML\n",
     "display(HTML(\"<style>.container { width:100% !important; }</style>\"))"
    ]
   },

--- a/notebooks/06.06-Introduction-to-Parametric-backbone-design.ipynb
+++ b/notebooks/06.06-Introduction-to-Parametric-backbone-design.ipynb
@@ -90,7 +90,7 @@
     "logging.basicConfig(level=logging.INFO)\n",
     "import pyrosetta\n",
     "\n",
-    "from IPython.core.display import display, HTML\n",
+    "from IPython.display import display, HTML\n",
     "display(HTML(\"<style>.container { width:100% !important; }</style>\"))"
    ]
   },

--- a/student-notebooks/06.03-Design-with-a-resfile-and-relax.ipynb
+++ b/student-notebooks/06.03-Design-with-a-resfile-and-relax.ipynb
@@ -79,7 +79,7 @@
     "import pyrosetta\n",
     "import pyrosetta.toolbox\n",
     "\n",
-    "from IPython.core.display import display, HTML\n",
+    "from IPython.display import display, HTML\n",
     "display(HTML(\"<style>.container { width:100% !important; }</style>\"))"
    ]
   },

--- a/student-notebooks/06.04-Protein-Design-2.ipynb
+++ b/student-notebooks/06.04-Protein-Design-2.ipynb
@@ -70,7 +70,7 @@
     "import pyrosetta.toolbox\n",
     "import site\n",
     "\n",
-    "from IPython.core.display import display, HTML\n",
+    "from IPython.display import display, HTML\n",
     "display(HTML(\"<style>.container { width:100% !important; }</style>\"))"
    ]
   },

--- a/student-notebooks/06.06-Introduction-to-Parametric-backbone-design.ipynb
+++ b/student-notebooks/06.06-Introduction-to-Parametric-backbone-design.ipynb
@@ -77,7 +77,7 @@
     "logging.basicConfig(level=logging.INFO)\n",
     "import pyrosetta\n",
     "\n",
-    "from IPython.core.display import display, HTML\n",
+    "from IPython.display import display, HTML\n",
     "display(HTML(\"<style>.container { width:100% !important; }</style>\"))"
    ]
   },


### PR DESCRIPTION
## Problem

With recent IPython versions, notebooks that do

```python
from IPython.core.display import display, HTML
```

fail on the very first cell:

```
ImportError: cannot import name 'display' from 'IPython.core.display'
```

`display` was moved out of `IPython.core.display` (to `IPython.core.display_functions`) in IPython 7.23, and the deprecated re-export has now been removed entirely, so the private-module import no longer resolves.

## Fix

Import both names from `IPython.display`, which is the documented public location and has re-exported `display` and `HTML` for every IPython version these notebooks support:

```python
from IPython.display import display, HTML
```

No `try`/`except ImportError` fallback is needed — this path works on both old and new IPython. Other cells in the same notebooks already use `from IPython.display import Image`, so this also makes the imports self-consistent.

## Affected notebooks

Three workshops used the old import (plus their `student-notebooks` counterparts):

- `06.03-Design-with-a-resfile-and-relax`
- `06.04-Protein-Design-2`
- `06.06-Introduction-to-Parametric-backbone-design`

The `notebooks/` and `student-notebooks/` copies were edited identically rather than regenerating via `make-student-nb.bash`; the cell is not nbgrader-processed, so the result matches what a regeneration produces. All six files re-validated as JSON, and no `IPython.core.display` imports remain in the repository.
